### PR TITLE
add ticker information retrieval and corresponding tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ go.work.sum
 .env
 
 # Editor/IDE
-# .idea/
-# .vscode/
+ .idea/
+ .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ go.work.sum
 .env
 
 # Editor/IDE
- .idea/
- .vscode/
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go get github.com/oscarli916/yahoo-finance-api
 
 ## Example
 
-```
+```go
 package main
 
 import (
@@ -47,6 +47,13 @@ func main() {
 	e := t.ExpirationDates()
 	oc := t.OptionChainByExpiration(e[2])
 	fmt.Println(oc)
+	
+	// Ticker Information
+	info, err := t.GetInfo()
+	if err != nil {
+		fmt.Println("GetInfo returned error:", err)
+	}
+	fmt.Println(info)
 }
 
 ```

--- a/information.go
+++ b/information.go
@@ -1,0 +1,80 @@
+package yahoofinanceapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/url"
+)
+
+// YahooInfoResponse --> Struct to hold the result from the Yahoo Finance quoteSummary endpoint
+type YahooInfoResponse struct {
+	QuoteSummary struct {
+		Result []struct {
+			Price YahooTickerInfo `json:"price"`
+		} `json:"result"`
+		Error interface{} `json:"error"`
+	} `json:"quoteSummary"`
+}
+
+// YahooTickerInfo --> Struct to hold key metadata about the ticker
+type YahooTickerInfo struct {
+	Symbol             string `json:"symbol"`
+	ShortName          string `json:"shortName"`
+	LongName           string `json:"longName"`
+	Currency           string `json:"currency"`
+	ExchangeName       string `json:"exchangeName"`
+	MarketState        string `json:"marketState"`
+	RegularMarketPrice struct {
+		Raw float64 `json:"raw"`
+		Fmt string  `json:"fmt"`
+	} `json:"regularMarketPrice"`
+}
+
+// Information holds the HTTP client
+type Information struct {
+	client *Client
+}
+
+// newInformation initializes the Information struct with an HTTP client
+func newInformation() *Information {
+	return &Information{client: getClient()}
+}
+
+// GetTickerInfo fetches metadata information for a given ticker
+func (i *Information) GetTickerInfo(symbol string) (YahooTickerInfo, error) {
+	// Prepare URL parameters to request the "price" module
+	params := url.Values{}
+	params.Add("modules", "price")
+
+	// Build the endpoint URL for the Yahoo Finance quoteSummary API
+	endpoint := fmt.Sprintf("%s/v10/finance/quoteSummary/%s", BASE_URL, symbol)
+
+	// Make the HTTP GET request using the client
+	resp, err := i.client.Get(endpoint, params)
+	if err != nil {
+		slog.Error("Failed to get ticker info", "err", err)
+		return YahooTickerInfo{}, err
+	}
+
+	// Read the response body
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return YahooTickerInfo{}, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Unmarshal the JSON response into the YahooInfoResponse struct
+	var infoResponse YahooInfoResponse
+	if err := json.Unmarshal(bodyBytes, &infoResponse); err != nil {
+		return YahooTickerInfo{}, fmt.Errorf("failed to decode info JSON: %w", err)
+	}
+
+	// Check if the result array is empty
+	if len(infoResponse.QuoteSummary.Result) == 0 {
+		return YahooTickerInfo{}, fmt.Errorf("no info found for symbol: %s", symbol)
+	}
+
+	// Return the ticker price information
+	return infoResponse.QuoteSummary.Result[0].Price, nil
+}

--- a/information.go
+++ b/information.go
@@ -18,18 +18,58 @@ type YahooInfoResponse struct {
 	} `json:"quoteSummary"`
 }
 
+// PriceValue represents a price value with raw and formatted representations
+type PriceValue struct {
+	Raw     float64 `json:"raw"`
+	Fmt     string  `json:"fmt"`
+	LongFmt string  `json:"longFmt,omitempty"`
+}
+
 // YahooTickerInfo --> Struct to hold key metadata about the ticker
 type YahooTickerInfo struct {
-	Symbol             string `json:"symbol"`
-	ShortName          string `json:"shortName"`
-	LongName           string `json:"longName"`
-	Currency           string `json:"currency"`
-	ExchangeName       string `json:"exchangeName"`
-	MarketState        string `json:"marketState"`
-	RegularMarketPrice struct {
-		Raw float64 `json:"raw"`
-		Fmt string  `json:"fmt"`
-	} `json:"regularMarketPrice"`
+	MaxAge                     int         `json:"maxAge"`
+	PreMarketChange            *PriceValue `json:"preMarketChange"`
+	PreMarketPrice             *PriceValue `json:"preMarketPrice"`
+	PreMarketSource            string      `json:"preMarketSource"`
+	PostMarketChangePercent    *PriceValue `json:"postMarketChangePercent"`
+	PostMarketChange           *PriceValue `json:"postMarketChange"`
+	PostMarketTime             int64       `json:"postMarketTime"`
+	PostMarketPrice            *PriceValue `json:"postMarketPrice"`
+	PostMarketSource           string      `json:"postMarketSource"`
+	RegularMarketChangePercent *PriceValue `json:"regularMarketChangePercent"`
+	RegularMarketChange        *PriceValue `json:"regularMarketChange"`
+	RegularMarketTime          int64       `json:"regularMarketTime"`
+	PriceHint                  *PriceValue `json:"priceHint"`
+	RegularMarketPrice         *PriceValue `json:"regularMarketPrice"`
+	RegularMarketDayHigh       *PriceValue `json:"regularMarketDayHigh"`
+	RegularMarketDayLow        *PriceValue `json:"regularMarketDayLow"`
+	RegularMarketVolume        *PriceValue `json:"regularMarketVolume"`
+	AverageDailyVolume10Day    *PriceValue `json:"averageDailyVolume10Day"`
+	AverageDailyVolume3Month   *PriceValue `json:"averageDailyVolume3Month"`
+	RegularMarketPreviousClose *PriceValue `json:"regularMarketPreviousClose"`
+	RegularMarketSource        string      `json:"regularMarketSource"`
+	RegularMarketOpen          *PriceValue `json:"regularMarketOpen"`
+	StrikePrice                *PriceValue `json:"strikePrice"`
+	OpenInterest               *PriceValue `json:"openInterest"`
+	Exchange                   string      `json:"exchange"`
+	ExchangeName               string      `json:"exchangeName"`
+	ExchangeDataDelayedBy      int         `json:"exchangeDataDelayedBy"`
+	MarketState                string      `json:"marketState"`
+	QuoteType                  string      `json:"quoteType"`
+	Symbol                     string      `json:"symbol"`
+	UnderlyingSymbol           *string     `json:"underlyingSymbol"`
+	ShortName                  string      `json:"shortName"`
+	LongName                   string      `json:"longName"`
+	Currency                   string      `json:"currency"`
+	QuoteSourceName            string      `json:"quoteSourceName"`
+	CurrencySymbol             string      `json:"currencySymbol"`
+	FromCurrency               *string     `json:"fromCurrency"`
+	ToCurrency                 *string     `json:"toCurrency"`
+	LastMarket                 *string     `json:"lastMarket"`
+	Volume24Hr                 *PriceValue `json:"volume24Hr"`
+	VolumeAllCurrencies        *PriceValue `json:"volumeAllCurrencies"`
+	CirculatingSupply          *PriceValue `json:"circulatingSupply"`
+	MarketCap                  *PriceValue `json:"marketCap"`
 }
 
 // Information holds the HTTP client
@@ -42,8 +82,8 @@ func newInformation() *Information {
 	return &Information{client: getClient()}
 }
 
-// GetTickerInfo fetches metadata information for a given ticker
-func (i *Information) GetTickerInfo(symbol string) (YahooTickerInfo, error) {
+// GetInfo fetches metadata information for a given ticker
+func (i *Information) GetInfo(symbol string) (YahooTickerInfo, error) {
 	// Prepare URL parameters to request the "price" module
 	params := url.Values{}
 	params.Add("modules", "price")

--- a/information_test.go
+++ b/information_test.go
@@ -1,0 +1,39 @@
+package yahoofinanceapi
+
+import (
+	"log"
+	"testing"
+)
+
+func TestNewInformation(t *testing.T) {
+	info := newInformation()
+	if info == nil {
+		t.Fatal("newInformation returned nil")
+	}
+}
+
+func TestGetTickerInfoValidSymbol(t *testing.T) {
+	info := newInformation()
+	data, err := info.GetTickerInfo("AAPL")
+	log.Println(data, err)
+	if err != nil {
+		t.Fatalf("GetTickerInfo returned error: %v", err)
+	}
+	if data.Symbol != "AAPL" {
+		t.Errorf("Expected symbol 'AAPL', got '%s'", data.Symbol)
+	}
+	if data.ShortName == "" {
+		t.Error("Expected non-empty ShortName")
+	}
+	if data.Currency == "" {
+		t.Error("Expected non-empty Currency")
+	}
+}
+
+func TestGetTickerInfoInvalidSymbol(t *testing.T) {
+	info := newInformation()
+	_, err := info.GetTickerInfo("INVALID_SYMBOL_123")
+	if err == nil {
+		t.Error("Expected error for invalid symbol, got nil")
+	}
+}

--- a/information_test.go
+++ b/information_test.go
@@ -14,7 +14,7 @@ func TestNewInformation(t *testing.T) {
 
 func TestGetTickerInfoValidSymbol(t *testing.T) {
 	info := newInformation()
-	data, err := info.GetTickerInfo("AAPL")
+	data, err := info.GetInfo("AAPL")
 	log.Println(data, err)
 	if err != nil {
 		t.Fatalf("GetTickerInfo returned error: %v", err)
@@ -22,17 +22,17 @@ func TestGetTickerInfoValidSymbol(t *testing.T) {
 	if data.Symbol != "AAPL" {
 		t.Errorf("Expected symbol 'AAPL', got '%s'", data.Symbol)
 	}
-	if data.ShortName == "" {
-		t.Error("Expected non-empty ShortName")
+	if data.ShortName != "Apple Inc." {
+		t.Errorf("Expected ShortName 'Apple Inc.', got '%s'", data.ShortName)
 	}
-	if data.Currency == "" {
-		t.Error("Expected non-empty Currency")
+	if data.Currency != "USD" {
+		t.Errorf("Expected Currency 'USD', got '%s'", data.Currency)
 	}
 }
 
 func TestGetTickerInfoInvalidSymbol(t *testing.T) {
 	info := newInformation()
-	_, err := info.GetTickerInfo("INVALID_SYMBOL_123")
+	_, err := info.GetInfo("INVALID_SYMBOL_123")
 	if err == nil {
 		t.Error("Expected error for invalid symbol, got nil")
 	}

--- a/ticker.go
+++ b/ticker.go
@@ -1,23 +1,28 @@
 package yahoofinanceapi
 
 import (
+	"fmt"
 	"sort"
 )
 
 type Ticker struct {
-	Symbol  string
-	history *History
-	option  *Option
+	Symbol      string
+	history     *History
+	option      *Option
+	information *Information
 }
 
+// NewTicker creates a new Ticker instance for the given symbol.
+// It initializes the history, option, and information components needed to fetch
+// historical price data, options data, and ticker information.
 func NewTicker(symbol string) *Ticker {
 	h := newHistory()
 	o := newOption()
-	return &Ticker{Symbol: symbol, history: h, option: o}
+	i := newInformation()
+	return &Ticker{Symbol: symbol, history: h, option: o, information: i}
 }
 
 // Quote returns the latest PriceData for the Ticker's symbol.
-//
 // This is a convenience wrapper around the History function. It fetches the historical
 // price data for the symbol, sorts the dates, and returns the most recent entry.
 // If you need more control or access to the full historical data, use the History method directly.
@@ -39,6 +44,24 @@ func (t *Ticker) Quote() (PriceData, error) {
 	return latestPriceData, nil
 }
 
+// GetInfo retrieves the ticker information for the Ticker's symbol.
+// It returns a YahooTickerInfo struct containing metadata such as the symbol, name, currency, and market state.
+// If no information is found, it returns an error.
+func (t *Ticker) GetInfo() (YahooTickerInfo, error) {
+	info, err := t.information.GetTickerInfo(t.Symbol)
+	if err != nil {
+		return YahooTickerInfo{}, err
+	}
+
+	if info.Symbol == "" {
+		return YahooTickerInfo{}, fmt.Errorf("no information found for symbol: %s", t.Symbol)
+	}
+	return info, nil
+}
+
+// History retrieves the historical price data for the Ticker's symbol based on the provided query.
+// It returns a map of date strings to PriceData structs.
+// The query can specify the range, interval, and other parameters for the historical data.
 func (t *Ticker) History(query HistoryQuery) (map[string]PriceData, error) {
 	t.history.SetQuery(query)
 	history, err := t.history.GetHistory(t.Symbol)
@@ -48,16 +71,24 @@ func (t *Ticker) History(query HistoryQuery) (map[string]PriceData, error) {
 	return t.history.transformData(history), nil
 }
 
+// OptionChain retrieves the option chain for the Ticker's symbol.
+// It returns an OptionData struct containing the options available for the ticker.
+// If no options are found, it returns an empty OptionData struct.
 func (t *Ticker) OptionChain() OptionData {
 	optionChain := t.option.GetOptionChain(t.Symbol)
 	return t.option.transformData(optionChain)
 }
 
+// OptionChainByExpiration retrieves the option chain for the Ticker's symbol filtered by a specific expiration date.
+// It returns an OptionData struct containing the options available for the ticker on that expiration date.
+// If no options are found for the specified expiration, it returns an empty OptionData struct.
 func (t *Ticker) OptionChainByExpiration(expiration string) OptionData {
 	optionChain := t.option.GetOptionChainByExpiration(t.Symbol, expiration)
 	return t.option.transformData(optionChain)
 }
 
+// ExpirationDates retrieves a list of available expiration dates for options on the Ticker's symbol.
+// It returns a slice of strings representing the expiration dates.
 func (t *Ticker) ExpirationDates() []string {
 	expirationDates := t.option.GetExpirationDates(t.Symbol)
 	return expirationDates

--- a/ticker.go
+++ b/ticker.go
@@ -44,17 +44,17 @@ func (t *Ticker) Quote() (PriceData, error) {
 	return latestPriceData, nil
 }
 
-// GetInfo retrieves the ticker information for the Ticker's symbol.
+// Info retrieves the ticker information for the Ticker's symbol.
 // It returns a YahooTickerInfo struct containing metadata such as the symbol, name, currency, and market state.
 // If no information is found, it returns an error.
-func (t *Ticker) GetInfo() (YahooTickerInfo, error) {
-	info, err := t.information.GetTickerInfo(t.Symbol)
+func (t *Ticker) Info() (YahooTickerInfo, error) {
+	info, err := t.information.GetInfo(t.Symbol)
 	if err != nil {
 		return YahooTickerInfo{}, err
 	}
 
-	if info.Symbol == "" {
-		return YahooTickerInfo{}, fmt.Errorf("no information found for symbol: %s", t.Symbol)
+	if info.Symbol != t.Symbol {
+		return YahooTickerInfo{}, fmt.Errorf("symbol mismatch: expected %s, got %s", t.Symbol, info.Symbol)
 	}
 	return info, nil
 }

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -33,6 +33,31 @@ func TestQuoteInvalidSymbol(t *testing.T) {
 	}
 }
 
+func TestGetInfoValidSymbol(t *testing.T) {
+	ticker := NewTicker("AAPL")
+	info, err := ticker.GetInfo()
+	if err != nil {
+		t.Fatalf("GetInfo returned error: %v", err)
+	}
+	if info.Symbol != "AAPL" {
+		t.Errorf("Expected symbol 'AAPL', got '%s'", info.Symbol)
+	}
+	if info.ShortName == "" {
+		t.Error("Expected non-empty ShortName")
+	}
+	if info.Currency == "" {
+		t.Error("Expected non-empty Currency")
+	}
+}
+
+func TestGetInfoInvalidSymbol(t *testing.T) {
+	ticker := NewTicker("INVALID_SYMBOL_123")
+	_, err := ticker.GetInfo()
+	if err == nil {
+		t.Error("Expected error for invalid symbol, got nil")
+	}
+}
+
 func TestHistoryValidSymbol(t *testing.T) {
 	ticker := NewTicker("AAPL")
 	query := HistoryQuery{Range: "1mo", Interval: "1d"}

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -35,24 +35,24 @@ func TestQuoteInvalidSymbol(t *testing.T) {
 
 func TestGetInfoValidSymbol(t *testing.T) {
 	ticker := NewTicker("AAPL")
-	info, err := ticker.GetInfo()
+	info, err := ticker.Info()
 	if err != nil {
 		t.Fatalf("GetInfo returned error: %v", err)
 	}
 	if info.Symbol != "AAPL" {
 		t.Errorf("Expected symbol 'AAPL', got '%s'", info.Symbol)
 	}
-	if info.ShortName == "" {
-		t.Error("Expected non-empty ShortName")
+	if info.ShortName != "Apple Inc." {
+		t.Errorf("Expected ShortName 'Apple Inc.', got '%s'", info.ShortName)
 	}
-	if info.Currency == "" {
-		t.Error("Expected non-empty Currency")
+	if info.Currency != "USD" {
+		t.Errorf("Expected Currency 'USD', got '%s'", info.Currency)
 	}
 }
 
 func TestGetInfoInvalidSymbol(t *testing.T) {
 	ticker := NewTicker("INVALID_SYMBOL_123")
-	_, err := ticker.GetInfo()
+	_, err := ticker.Info()
 	if err == nil {
 		t.Error("Expected error for invalid symbol, got nil")
 	}


### PR DESCRIPTION
This pull request introduces functionality to retrieve ticker metadata from Yahoo Finance, including a new `GetInfo` method for the `Ticker` class, supporting structures, and corresponding tests. Key changes include the addition of a new `Information` component, updates to the `Ticker` class, and enhancements to the documentation and tests.

### New functionality for retrieving ticker metadata:

* [`information.go`](diffhunk://#diff-0e382205cbb0d1d8c129904a8d564cba44fde31ae4cb9d5a0de52b19c5fe8a4dR1-R80): Added `Information` struct and `GetTickerInfo` method to fetch ticker metadata using the Yahoo Finance API. Introduced `YahooInfoResponse` and `YahooTickerInfo` structs for parsing API responses.
* [`ticker.go`](diffhunk://#diff-0fa1c5e594767eab236a659efb91b0a6b2431187670cc433d5ac4be8b6b4b3efR4-L20): Integrated the `Information` component into the `Ticker` class and added the `GetInfo` method to retrieve metadata for a ticker's symbol. Updated `NewTicker` to initialize the `Information` component. [[1]](diffhunk://#diff-0fa1c5e594767eab236a659efb91b0a6b2431187670cc433d5ac4be8b6b4b3efR4-L20) [[2]](diffhunk://#diff-0fa1c5e594767eab236a659efb91b0a6b2431187670cc433d5ac4be8b6b4b3efR47-R64)

### Unit tests for the new functionality:

* [`information_test.go`](diffhunk://#diff-b09d8c62a63d0c8b4875592a12b467decc8f2e491b5913887855484bf23ef757R1-R39): Added tests for the `Information` struct, including `TestNewInformation`, `TestGetTickerInfoValidSymbol`, and `TestGetTickerInfoInvalidSymbol`.
* [`ticker_test.go`](diffhunk://#diff-03894102ba3768cd78a10d15f83b989e059a5e6135a83dfac86422a8cd362addR36-R60): Added `TestGetInfoValidSymbol` and `TestGetInfoInvalidSymbol` to validate the `GetInfo` method in the `Ticker` class.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18): Updated the example code to include usage of the new `GetInfo` method for retrieving ticker metadata. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R56)